### PR TITLE
Blacklist items involving pref `prusias_profitTracking_blackList`

### DIFF
--- a/scripts/ptrackSuite/ProfitTracking.ash
+++ b/scripts/ptrackSuite/ProfitTracking.ash
@@ -79,7 +79,20 @@ int ProfitCompareItem( boolean silent, string date1, string event1, string date2
 	itemcount [int] diff;
 	int difference;
 	int profit;
+
+	boolean[item] blacklistedItems;
+	
+	foreach x, it in get_property("prusias_profitTracking_blackList").split_string('(?<!\\\\)(, |,)') {
+		it = replace_all(create_matcher(`\\\\`, it), "");
+		blacklistedItems[it.to_item()] = true;
+	}
+
 	foreach it in $items[] {
+
+		if(blacklistedItems contains it){
+			continue;
+		}
+
 		if ( itemList1[it] != itemList2[it] ) {
 			difference = itemList2[it]-itemList1[it];
 			diff[diff.count()] = new itemcount(it, difference);


### PR DESCRIPTION
Use:
Setting `prusias_profitTracking_blackList` to 

`Pantsgiving, spice melange, battery (AAA), jumping horseradish, groveling gravel, KoL Con 13 snowglobe, battery (9-volt),repaid diaper,Bag o' Tricks,Platinum Yendorian Express Card, Aye Aye\, Captain`

Block the following items from being recorded as 'profit' during both new and old pTrack comparisons:

Platinum Yendorian Express Card
spice melange
Bag o' Tricks
Aye Aye, Captain
Pantsgiving
jumping horseradish
repaid diaper
KoL Con 13 snowglobe
battery (AAA)
battery (9-Volt)
groveling gravel